### PR TITLE
Pin `cheerio` to `1.0.0-rc.12`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22346,7 +22346,7 @@
       "version": "2.0.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "cheerio": "^1.0.0-rc.12",
+        "cheerio": "1.0.0-rc.12",
         "deepmerge": "^4.3.1"
       },
       "devDependencies": {
@@ -22381,7 +22381,7 @@
         "@babel/code-frame": "^7.24.7",
         "@linthtml/linthtml": "^0.9.6",
         "async": "^3.2.5",
-        "cheerio": "^1.0.0-rc.12",
+        "cheerio": "1.0.0-rc.12",
         "deepmerge": "^4.3.1"
       },
       "devDependencies": {
@@ -22415,7 +22415,7 @@
       "version": "2.0.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "cheerio": "^1.0.0-rc.12",
+        "cheerio": "1.0.0-rc.12",
         "deepmerge": "^4.3.1",
         "minimatch": "^9.0.3"
       },
@@ -22470,7 +22470,7 @@
       "version": "2.0.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "cheerio": "^1.0.0-rc.12",
+        "cheerio": "1.0.0-rc.12",
         "deepmerge": "^4.3.1",
         "sync-request": "^6.1.0"
       },
@@ -22503,7 +22503,7 @@
       "version": "2.0.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "cheerio": "^1.0.0-rc.12",
+        "cheerio": "1.0.0-rc.12",
         "deepmerge": "^4.3.1"
       },
       "devDependencies": {
@@ -22569,7 +22569,7 @@
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "async": "^3.2.5",
-        "cheerio": "^1.0.0-rc.12",
+        "cheerio": "1.0.0-rc.12",
         "deepmerge": "^4.3.1",
         "top-user-agents": "^2.1.22"
       },

--- a/packages/metalsmith-html-glob/package.json
+++ b/packages/metalsmith-html-glob/package.json
@@ -47,7 +47,7 @@
     "postpack": "rm ./LICENSE"
   },
   "dependencies": {
-    "cheerio": "^1.0.0-rc.12",
+    "cheerio": "1.0.0-rc.12",
     "deepmerge": "^4.3.1"
   },
   "peerDependencies": {

--- a/packages/metalsmith-html-glob/package.json
+++ b/packages/metalsmith-html-glob/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-html-glob",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A Metalsmith plugin to apply glob patterns within HTML.",
   "keywords": [
     "metalsmith",

--- a/packages/metalsmith-html-linter/package.json
+++ b/packages/metalsmith-html-linter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-html-linter",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "A Metalsmith plugin to lint HTML.",
   "keywords": [
     "metalsmith",

--- a/packages/metalsmith-html-linter/package.json
+++ b/packages/metalsmith-html-linter/package.json
@@ -50,7 +50,7 @@
     "@babel/code-frame": "^7.24.7",
     "@linthtml/linthtml": "^0.9.6",
     "async": "^3.2.5",
-    "cheerio": "^1.0.0-rc.12",
+    "cheerio": "1.0.0-rc.12",
     "deepmerge": "^4.3.1"
   },
   "peerDependencies": {

--- a/packages/metalsmith-html-relative/package.json
+++ b/packages/metalsmith-html-relative/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-html-relative",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A Metalsmith plugin to convert to relative paths within HTML.",
   "keywords": [
     "metalsmith",

--- a/packages/metalsmith-html-relative/package.json
+++ b/packages/metalsmith-html-relative/package.json
@@ -47,7 +47,7 @@
     "postpack": "rm ./LICENSE"
   },
   "dependencies": {
-    "cheerio": "^1.0.0-rc.12",
+    "cheerio": "1.0.0-rc.12",
     "deepmerge": "^4.3.1",
     "minimatch": "^9.0.3"
   },

--- a/packages/metalsmith-html-sri/package.json
+++ b/packages/metalsmith-html-sri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-html-sri",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A Metalsmith to add subresource integrity attributes to HTML.",
   "keywords": [
     "metalsmith",

--- a/packages/metalsmith-html-sri/package.json
+++ b/packages/metalsmith-html-sri/package.json
@@ -47,7 +47,7 @@
     "postpack": "rm ./LICENSE"
   },
   "dependencies": {
-    "cheerio": "^1.0.0-rc.12",
+    "cheerio": "1.0.0-rc.12",
     "deepmerge": "^4.3.1",
     "sync-request": "^6.1.0"
   },

--- a/packages/metalsmith-html-unused/package.json
+++ b/packages/metalsmith-html-unused/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-html-unused",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A Metalsmith plugin to exclude files unused in HTML.",
   "keywords": [
     "metalsmith",

--- a/packages/metalsmith-html-unused/package.json
+++ b/packages/metalsmith-html-unused/package.json
@@ -47,7 +47,7 @@
     "postpack": "rm ./LICENSE"
   },
   "dependencies": {
-    "cheerio": "^1.0.0-rc.12",
+    "cheerio": "1.0.0-rc.12",
     "deepmerge": "^4.3.1"
   },
   "peerDependencies": {

--- a/packages/metalsmith-link-checker/package.json
+++ b/packages/metalsmith-link-checker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-link-checker",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "A Metalsmith plugin to check for broken links.",
   "keywords": [
     "metalsmith",

--- a/packages/metalsmith-link-checker/package.json
+++ b/packages/metalsmith-link-checker/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "async": "^3.2.5",
-    "cheerio": "^1.0.0-rc.12",
+    "cheerio": "1.0.0-rc.12",
     "deepmerge": "^4.3.1",
     "top-user-agents": "^2.1.22"
   },

--- a/packages/metalsmith-mermaid/test/index.test.ts
+++ b/packages/metalsmith-mermaid/test/index.test.ts
@@ -10,7 +10,7 @@ import { join } from 'path';
 // import assertDir from 'assert-dir-equal';
 import mermaid, { Options } from '../index.js';
 
-jest.setTimeout(15_000);
+jest.setTimeout(20_000);
 
 interface Config {
   options: Options,


### PR DESCRIPTION
Fixes https://github.com/emmercm/metalsmith-plugins/issues/150

Cheerio 1.0.0 removed their `default` export and bumped the minimum Node.js version, so it's not compatible with these plugins anymore. This PR pins it to the latest working version.

This is a non-breaking alternative to #151.